### PR TITLE
Implmented dedicated Axios instances for client-side and server-side …

### DIFF
--- a/src/app/api/auth/delete-account/route.ts
+++ b/src/app/api/auth/delete-account/route.ts
@@ -1,8 +1,7 @@
-// app/api/auth/delete-account/route.ts
 import { NextResponse } from "next/server"
 import { ENV } from "@/lib/env"
 import { cookies } from "next/headers"
-import axios from "axios"
+import serverAxiosInstance from "@/lib/server-axios";
 
 export async function DELETE() {
   const cookieStore: any = cookies()
@@ -14,11 +13,7 @@ export async function DELETE() {
 
   try {
     // Call backend delete account API
-    const backendRes = await axios.delete(`${ENV.backendBaseUrl}/auth/account`, {
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+    const backendRes = await serverAxiosInstance.delete(`/auth/account`, {
       validateStatus: () => true,
     })
 

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,15 +1,13 @@
-// app/api/auth/login/route.ts
 import { NextRequest, NextResponse } from "next/server"
 import { ENV } from "@/lib/env"
-import axios from "axios"
+import serverAxiosInstance from "@/lib/server-axios";
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json()
 
     // Call backend login
-    const res = await axios.post(`${ENV.backendBaseUrl}/auth/login`, body, {
-      headers: { "Content-Type": "application/json" },
+    const res = await serverAxiosInstance.post(`/auth/login`, body, {
       validateStatus: () => true, // allow handling non-2xx responses
     })
 

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,8 +1,7 @@
-// app/api/auth/logout/route.ts
 import { NextRequest, NextResponse } from "next/server"
 import { ENV } from "@/lib/env"
 import { cookies } from "next/headers"
-import axios from "axios"
+import serverAxiosInstance from "@/lib/server-axios";
 
 
 export async function POST(req: NextRequest) {
@@ -13,15 +12,11 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    // Call backend logout
-    const backendRes = await axios.post(
-      `${ENV.backendBaseUrl}/auth/logout`,
-      {}, // no body, just an empty object
+    
+    const backendRes = await serverAxiosInstance.post(
+      `/auth/logout`,
+      {}, 
       {
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
         validateStatus: () => true,
       }
     )

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,0 +1,34 @@
+import axios from "axios";
+import { ENV } from "./env";
+
+const axiosInstance = axios.create({
+  baseURL: ENV.backendBaseUrl,
+  withCredentials: true,
+});
+
+axiosInstance.interceptors.request.use(
+  (config) => {
+    // We will add logic here to inject tokens or other headers if needed
+    
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+axiosInstance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      // Redirect to login page or trigger a logout action
+      // For example:
+      window.location.href = "/login"; // Assuming a login route
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default axiosInstance;

--- a/src/lib/server-axios.ts
+++ b/src/lib/server-axios.ts
@@ -1,0 +1,35 @@
+import axios from "axios";
+import { ENV } from "./env";
+import { getTokenFromCookies } from "./cookies";
+
+const serverAxiosInstance = axios.create({
+  baseURL: ENV.backendBaseUrl,
+  
+});
+
+serverAxiosInstance.interceptors.request.use(
+  async (config) => {
+    const token = await getTokenFromCookies();
+
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+serverAxiosInstance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    // Server-side error handling can be added here
+    console.error("Server-side Axios error:", error.message);
+    return Promise.reject(error);
+  }
+);
+
+export default serverAxiosInstance;

--- a/src/lib/stores/useUserStore.ts
+++ b/src/lib/stores/useUserStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import axios from "axios";
+import axiosInstance from "@/lib/axios";
 
 type User = {
   id: string;
@@ -27,7 +27,7 @@ export const useUserStore = create<AuthState>((set) => ({
 
   loadSession: async () => {
     try {
-       const res = await axios.get("/api/auth/profile", { withCredentials: true });
+       const res = await axiosInstance.get("/api/auth/profile");
 
       if (res.status !== 200) {
         if (res.status === 401) {
@@ -46,7 +46,7 @@ export const useUserStore = create<AuthState>((set) => ({
   },
   logout: () => {
 
-    axios
+    axiosInstance
       .post("/api/auth/logout", {}, { withCredentials: true })
       .catch((err) => console.error("Logout error:", err));
     set({ user: null, isLoggedIn: false });

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -2,7 +2,7 @@
 
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
-import axios from "axios";
+import axiosInstance from "@/lib/axios";
 import type { User } from "./types";
 
 interface AuthState {
@@ -44,9 +44,7 @@ export const useAuthStore = create<AuthState>()(
     fetchCurrentUser: async () => {
       set({ isLoading: true });
       try {
-        const res = await axios.get("/api/auth/profile", {
-          withCredentials: true,
-        });
+        const res = await axiosInstance.get("/api/auth/profile");
         const user: User = res.data.user;
         set({ user, isAuthenticated: true, isLoading: false });
       } catch {
@@ -57,10 +55,9 @@ export const useAuthStore = create<AuthState>()(
     register: async ({ name, email, password }) => {
       set({ isLoading: true, error: null, success: null });
       try {
-        await axios.post(
+        await axiosInstance.post(
           "/api/auth/register",
-          { name, email, password },
-          { withCredentials: true }
+          { name, email, password }
         );
 
         
@@ -79,10 +76,9 @@ export const useAuthStore = create<AuthState>()(
     login: async ({ email, password }) => {
       set({ isLoading: true, error: null, success: null });
       try {
-        await axios.post(
+        await axiosInstance.post(
           "/api/auth/login",
-          { email, password },
-          { withCredentials: true }
+          { email, password }
         );
         await get().fetchCurrentUser();
       } catch (err: any) {
@@ -96,10 +92,9 @@ export const useAuthStore = create<AuthState>()(
     loginWithGoogle: async (googleToken: string) => {
       set({ isLoading: true, error: null, success: null });
       try {
-        await axios.post(
+        await axiosInstance.post(
           "/api/auth/google",
-          { token: googleToken },
-          { withCredentials: true }
+          { token: googleToken }
         );
         await get().fetchCurrentUser();
       } catch (err: any) {
@@ -112,7 +107,7 @@ export const useAuthStore = create<AuthState>()(
 
     logout: async () => {
       try {
-        await axios.post("/api/auth/logout", {}, { withCredentials: true });
+        await axiosInstance.post("/api/auth/logout", {});
       } finally {
         set({
           user: null,
@@ -129,10 +124,9 @@ export const useAuthStore = create<AuthState>()(
     verifyOtp: async (email: string, otp: string) => {
       set({ otpStatus: "pending", error: null, success: null });
       try {
-        const res = await axios.post(
+        const res = await axiosInstance.post(
           "/api/auth/verify-otp",
-          { email, otp },
-          { withCredentials: true }
+          { email, otp }
         );
 
         if (res.data.success) {
@@ -157,10 +151,9 @@ export const useAuthStore = create<AuthState>()(
 
     resendOtp: async (email: string, name: string) => {
       try {
-        await axios.post(
+        await axiosInstance.post(
           "/api/auth/resend-otp",
-          { email, name },
-          { withCredentials: true }
+          { email, name }
         );
         set({ success: "OTP resent successfully. Check your email." });
       } catch (err: any) {


### PR DESCRIPTION
feat(http-client): Centralize Axios configuration with interceptors

Introduced dedicated Axios instances for client-side and server-side HTTP requests to standardize API interactions and enhance error handling.

- Created `src/lib/axios.ts` for client-side requests:
    - Configured `baseURL` from `ENV.backendBaseUrl` and `withCredentials: true`.
    - Implemented a response interceptor to handle `401 Unauthorized` errors by redirecting to the login page.
- Created `src/lib/server-axios.ts` for server-side API routes:
    - Configured `baseURL` from `ENV.backendBaseUrl`.
    - Implemented a request interceptor to dynamically retrieve the JWT token from `next/headers` cookies using `getTokenFromCookies` and inject it into the `Authorization` header.
    - Added a response interceptor for server-side error logging.
- Refactored existing direct Axios calls to use the new centralized instances:
    - Client-side stores (`src/lib/stores/useUserStore.ts`, `src/stores/authStore.ts`) now utilize `axiosInstance`.
    - Server-side API routes (`src/app/api/auth/login/route.ts`, `src/app/api/auth/logout/route.ts`, `src/app/api/auth/delete-account/route.ts`) now utilize `serverAxiosInstance`.
- Eliminated code duplication by refactoring `src/lib/server-axios.ts` to use the `getTokenFromCookies` helper from `src/lib/cookies.ts` for consistent cookie access.
- Conducted a comprehensive analysis of all other store files in `src/stores/` to confirm they either use the native `fetch` API or do not perform network requests, ensuring no remaining direct Axios calls.

These changes improve maintainability, reduce boilerplate, and centralize error handling and authentication logic for all Axios-based HTTP requests.